### PR TITLE
eliminates caching when fetching user messages

### DIFF
--- a/src/services/userMessages/httpUserMessagesList.ts
+++ b/src/services/userMessages/httpUserMessagesList.ts
@@ -24,6 +24,13 @@ export const handler = async (event: APIGatewayProxyEvent) => {
       userMessageResults = await UserMessage.allByStatus(selectedStatus, lastKey);
     } else {
       userMessageResults = await UserMessage.findAll(osuId!, lastKey);
+      return successResponse({
+        cacheSeconds: 0,
+        body: responseBody({
+          action,
+          object: { userMessageResults },
+        }),
+      });
     }
 
     return successResponse({


### PR DESCRIPTION
eliminate cloudfront caching for usermessage list API calls when it's for a specific user by ID